### PR TITLE
Cria estrutura inicial para acervo de estudos

### DIFF
--- a/docs/acervo.md
+++ b/docs/acervo.md
@@ -1,0 +1,24 @@
+# Acervo de Estudos
+
+Esta página reúne as principais trilhas de conhecimento que estou estudando. Cada seção contém anotações, resumos e referências úteis para revisitar os conceitos quando necessário.
+
+## Como navegar
+
+- Use o menu lateral para escolher uma área de estudo.
+- Cada tópico apresenta uma visão geral e links para materiais complementares.
+- Sempre que possível, adiciono exemplos práticos e exercícios resolvidos.
+
+## Trilhas disponíveis
+
+### Backend
+Conceitos fundamentais sobre APIs, bancos de dados, arquitetura e boas práticas de desenvolvimento do lado do servidor.
+
+### Frontend
+Anotações sobre interfaces, frameworks modernos, componentização e experiência do usuário.
+
+### DevOps
+Práticas para entregar software com qualidade e rapidez: automação, observabilidade, infraestrutura e cultura.
+
+---
+
+Novos tópicos serão adicionados conforme avanço nos estudos. Este é um projeto vivo, construído passo a passo.

--- a/docs/backend/apis.md
+++ b/docs/backend/apis.md
@@ -1,0 +1,16 @@
+# APIs
+
+Notas e recursos para construir APIs robustas e escaláveis.
+
+## Tópicos planejados
+
+- Estruturação de endpoints e versionamento.
+- Documentação com OpenAPI/Swagger.
+- Testes automatizados para garantir estabilidade.
+- Observabilidade: logs, métricas e tracing.
+
+## Referências iniciais
+
+- [RESTful API Design](https://restfulapi.net/)
+- [GraphQL Documentation](https://graphql.org/learn/)
+- [12 Factor App](https://12factor.net/)

--- a/docs/backend/index.md
+++ b/docs/backend/index.md
@@ -1,0 +1,15 @@
+# Backend
+
+Bem-vindo à trilha de backend! Aqui organizo conceitos, anotações e referências sobre desenvolvimento do lado do servidor.
+
+## Objetivos de estudo
+
+- Entender fundamentos de HTTP, REST e GraphQL.
+- Praticar modelagem de dados e integração com bancos relacionais e NoSQL.
+- Explorar padrões arquiteturais, testes automatizados e boas práticas de segurança.
+
+## Próximos passos
+
+1. Definir o stack principal que será usado nos exemplos.
+2. Escrever guias práticos sobre autenticação, autorização e versionamento de APIs.
+3. Adicionar estudos de caso de projetos reais.

--- a/docs/devops/index.md
+++ b/docs/devops/index.md
@@ -1,0 +1,15 @@
+# DevOps
+
+Aqui concentro práticas para integrar desenvolvimento e operações de forma colaborativa.
+
+## Objetivos de estudo
+
+- Automatizar pipelines de build, teste e deploy.
+- Monitorar aplicações e infraestrutura com ferramentas modernas.
+- Aperfeiçoar estratégias de observabilidade e resposta a incidentes.
+
+## Próximos passos
+
+1. Mapear ferramentas preferidas para CI/CD.
+2. Criar guias rápidos de containerização e orquestração.
+3. Documentar lições aprendidas de incidentes reais.

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -1,0 +1,15 @@
+# Frontend
+
+Seção dedicada a interfaces ricas, acessíveis e performáticas.
+
+## Objetivos de estudo
+
+- Aprimorar fundamentos de HTML, CSS e JavaScript moderno.
+- Experimentar bibliotecas e frameworks como React, Next.js e Tailwind.
+- Explorar testes de interface, acessibilidade e boas práticas de UX.
+
+## Próximos passos
+
+1. Criar guia de estilos base para os projetos de exemplo.
+2. Documentar padrões de componentes reutilizáveis.
+3. Registrar insights de performance e otimizações.

--- a/docs/frontend/react.md
+++ b/docs/frontend/react.md
@@ -1,0 +1,16 @@
+# React
+
+Resumo dos estudos e experimentos com o ecossistema React.
+
+## Tópicos planejados
+
+- Fundamentos: componentes, props, estado e ciclos de vida.
+- Hooks mais utilizados e padrões de composição.
+- Gerenciamento de estado com Context API, Redux e alternativas.
+- Boas práticas de testes com Testing Library e Jest.
+
+## Recursos recomendados
+
+- [Documentação oficial do React](https://react.dev/)
+- [Epic React](https://epicreact.dev/)
+- [Testing Library](https://testing-library.com/docs/react-testing-library/intro/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,26 @@
-# Welcome to MkDocs
+# Olá, eu sou o Mateus!
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+Bem-vindo ao meu acervo de estudos. Este espaço é o lugar onde organizo tudo o que estou aprendendo, compartilhando um pouco da minha jornada como desenvolvedor.
 
-## Commands
+## Sobre mim
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+Sou um desenvolvedor focado em construir soluções que impactem positivamente as pessoas. Tenho interesse por backend, frontend e práticas de DevOps, sempre buscando escrever código limpo, escalável e bem testado.
 
-## Project layout
+- 💡 **Especialidades atuais:** Node.js, TypeScript, React e Docker.
+- 📚 **Estudo contínuo:** arquitetura de software, design patterns e boas práticas de engenharia.
+- 🤝 **O que me move:** colaboração, desafios técnicos e projetos que geram valor real.
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+## Projetos em destaque
+
+### Plataforma de Estudos Pessoais
+Um sistema que reúne anotações, referências e exemplos de código organizados por tema. É a base deste acervo e do meu aprendizado contínuo.
+
+### API de Monitoramento de Serviços
+Serviço backend criado para consolidar métricas de aplicações distribuídas e emitir alertas em tempo real quando algo foge do esperado.
+
+### Experimentos com Frontend Moderno
+Pequenos projetos em React e Next.js voltados a testar novas bibliotecas, padrões de componentes e estratégias de state management.
+
+---
+
+Sinta-se à vontade para explorar as seções de documentação e acompanhar como este acervo evolui ao longo do tempo.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,10 +18,13 @@ markdown_extensions:
 
 nav:
   - Início: index.md
-  - Backend:
-      - Introdução: backend/index.md
-      - APIs: backend/apis.md
-  - Frontend:
-      - Introdução: frontend/index.md
-      - React: frontend/react.md
-  - DevOps: devops/index.md
+  - Documentação:
+      - Visão Geral: acervo.md
+      - Backend:
+          - Introdução: backend/index.md
+          - APIs: backend/apis.md
+      - Frontend:
+          - Introdução: frontend/index.md
+          - React: frontend/react.md
+      - DevOps:
+          - Introdução: devops/index.md


### PR DESCRIPTION
## Summary
- cria página inicial com apresentação pessoal e projetos em destaque
- adiciona página de visão geral para o acervo de estudos
- estrutura seções iniciais para backend, frontend e devops
- ajusta navegação do MkDocs para refletir a nova organização

## Testing
- mkdocs build *(fails: mkdocs não está instalado no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68db3eb20b708328a71db1854271b85d